### PR TITLE
Handle wrong password submissions

### DIFF
--- a/hooks/useAirtable.ts
+++ b/hooks/useAirtable.ts
@@ -23,10 +23,10 @@ const useAirtable = () => {
       const resJson = await res.json()
 
       if (resJson.status === 'success') {
-        return resJson.data
+        return { status: res.status, data: resJson.data }
       }
 
-      throw resJson.error
+      return { status: res.status }
     } catch (error: any) {
       throw new Error(error)
     }

--- a/pages/api/password/[...input].ts
+++ b/pages/api/password/[...input].ts
@@ -28,12 +28,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return ret
   }
 
+  let returned = false
   const stages = (await getStages()).map((elem) => {
     const fields = elem.fields
 
     // Send a 403 response if the password is wrong
     if (password !== fields.password) {
       res.status(403).send({ message: 'Unauthorized' })
+      returned = true
       return
     }
 
@@ -41,6 +43,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return key.indexOf('called') === 0 || key.indexOf('space') === 0
     }) as [string, string][]
   })
+  if (returned) return
 
   let calledSpaces: string[] = []
   stages.forEach((stageElem) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Box, Container, Heading } from '@chakra-ui/react'
+import { Box, Container, Heading, useToast } from '@chakra-ui/react'
 import { BingoCard } from '@/components/BingoCard'
 import { JoinButton } from '@/components/JoinButton'
 import { PasswordButton } from '@/components/PasswordButton'
@@ -17,6 +17,7 @@ export default function Home() {
   const [stage, setStage] = useState('')
   const [stageData, setStageData] = useState<StageData[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const toast = useToast()
 
   const joinBingo = (joinData: { username: string; stage: string }) => {
     setUsername(joinData.username)
@@ -41,7 +42,22 @@ export default function Home() {
     setIsLoading(false)
 
     // No correct spaces were returned
-    if (!ret || ret.status >= 400) return
+    if (!ret || ret.status >= 400) {
+      if (ret.status === 403) {
+        toast({
+          title: 'Palabra clave incorrecta',
+          status: 'warning',
+          isClosable: true
+        })
+        return
+      }
+      toast({
+        title: 'Error al acceder a la API',
+        status: 'error',
+        isClosable: true
+      })
+      return
+    }
 
     if (document === undefined || document === null) return
     const revealEvent = new CustomEvent('revealEvent', {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,11 +34,18 @@ export default function Home() {
     // (podcast episode titles) look like this: "A2 #8"
     const argsStage = passwordData.stage.replace(' #', '-')
     setIsLoading(true)
-    const ret = await checkPassword(argsPassword, argsStage)
+    const ret: { status: number; data?: any } | undefined = await checkPassword(
+      argsPassword,
+      argsStage
+    )
     setIsLoading(false)
+
+    // No correct spaces were returned
+    if (!ret || ret.status >= 400) return
+
     if (document === undefined || document === null) return
     const revealEvent = new CustomEvent('revealEvent', {
-      detail: ret
+      detail: ret.data
     })
     document.querySelector('body')?.dispatchEvent(revealEvent)
   }


### PR DESCRIPTION
Close #63

- Avoid sending multiple responses
- Handle wrong password responses
- Added toasts for non-successful password API responses
