### PR TITLE
Handle connectivity problems

### DIFF
--- a/components/JoinButton/index.tsx
+++ b/components/JoinButton/index.tsx
@@ -47,9 +47,10 @@ export function JoinButton(props: { funct: Function }) {
 
   useEffect(() => {
     if (!isOpen) return
-    const stageData: StageData[] = JSON.parse(
-      localStorage.getItem('bingoStageData') ?? '{}'
+    const stageData: StageData[] | { status: string } = JSON.parse(
+      localStorage.getItem('bingoStageData') ?? '[]'
     )
+    if (stageData.constructor !== Array || stageData.length < 1) return
     const availableStages = stageData.filter((elem) => {
       const airDate = new Date(elem.airdate)
       let latestDate = new Date()

--- a/components/JoinButton/index.tsx
+++ b/components/JoinButton/index.tsx
@@ -51,7 +51,7 @@ export function JoinButton(props: { funct: Function }) {
     if (!isOpen) return
     let noStagesFound = false
     let availableStages: StageData[] = []
-    const stageData: StageData[] | { status: string } = JSON.parse(
+    const stageData: StageData[] | { status: number } = JSON.parse(
       localStorage.getItem('bingoStageData') ?? '[]'
     )
     if (stageData.constructor !== Array || stageData.length < 1) {
@@ -65,7 +65,6 @@ export function JoinButton(props: { funct: Function }) {
       })
     }
     if (noStagesFound) {
-      console.log('no stages')
       toast({
         title: t('toast.no-stages-found'),
         status: 'error',

--- a/components/JoinButton/index.tsx
+++ b/components/JoinButton/index.tsx
@@ -10,6 +10,7 @@ import {
   ModalFooter,
   ModalBody,
   ModalCloseButton,
+  useToast,
   FormControl,
   FormLabel,
   FormErrorMessage,
@@ -26,6 +27,7 @@ const DAYS_IN_THE_FUTURE = 3
 
 export function JoinButton(props: { funct: Function }) {
   const { t } = useTranslation('common')
+  const toast = useToast()
   const isJoined = useJoined()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [joined, setJoined] = useState(false)
@@ -47,16 +49,31 @@ export function JoinButton(props: { funct: Function }) {
 
   useEffect(() => {
     if (!isOpen) return
+    let noStagesFound = false
+    let availableStages: StageData[] = []
     const stageData: StageData[] | { status: string } = JSON.parse(
       localStorage.getItem('bingoStageData') ?? '[]'
     )
-    if (stageData.constructor !== Array || stageData.length < 1) return
-    const availableStages = stageData.filter((elem) => {
-      const airDate = new Date(elem.airdate)
-      let latestDate = new Date()
-      latestDate.setDate(latestDate.getDate() + DAYS_IN_THE_FUTURE)
-      return airDate.getTime() <= latestDate.getTime()
-    })
+    if (stageData.constructor !== Array || stageData.length < 1) {
+      noStagesFound = true
+    } else {
+      availableStages = stageData.filter((elem) => {
+        const airDate = new Date(elem.airdate)
+        let latestDate = new Date()
+        latestDate.setDate(latestDate.getDate() + DAYS_IN_THE_FUTURE)
+        return airDate.getTime() <= latestDate.getTime()
+      })
+    }
+    if (noStagesFound) {
+      console.log('no stages')
+      toast({
+        title: t('toast.no-stages-found'),
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      })
+      return
+    }
     const ids = availableStages.map((elem) => {
       return elem.title
     })

--- a/hooks/useAirtable.ts
+++ b/hooks/useAirtable.ts
@@ -9,7 +9,7 @@ const useAirtable = () => {
 
       return { status: res.status }
     } catch (error: any) {
-      return { status: 'error' }
+      return { status: 503 }
     }
   }
 

--- a/hooks/useAirtable.ts
+++ b/hooks/useAirtable.ts
@@ -27,7 +27,7 @@ const useAirtable = () => {
 
       return { status: res.status }
     } catch (error: any) {
-      throw new Error(error)
+      return { status: 503 }
     }
   }
 

--- a/hooks/useAirtable.ts
+++ b/hooks/useAirtable.ts
@@ -3,14 +3,13 @@ const useAirtable = () => {
     try {
       const res = await fetch('/api/get-stages')
       const resJson = await res.json()
-
       if (resJson.status === 'success') {
         return resJson.data
       }
 
-      throw resJson.error
+      return { status: res.status }
     } catch (error: any) {
-      throw new Error(error)
+      return { status: 'error' }
     }
   }
 

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -4,7 +4,8 @@
     "correct-password": "Palabra clave correcta",
     "wrong-password": "Palabra clave incorrecta",
     "api-error": "Error al acceder a la API",
-    "connection-error": "No se pudo conectar con la API"
+    "connection-error": "No se pudo conectar con la API",
+    "no-stages-found": "No hay episodios disponibles"
   },
   "join": {
     "join-button": "Apuntarse",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -3,7 +3,8 @@
   "toast": {
     "correct-password": "Palabra clave correcta",
     "wrong-password": "Palabra clave incorrecta",
-    "api-error": "Error al acceder a la API"
+    "api-error": "Error al acceder a la API",
+    "connection-error": "No se pudo conectar con la API"
   },
   "join": {
     "join-button": "Apuntarse",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -44,7 +44,16 @@ export default function Home() {
     setIsLoading(false)
 
     // No correct spaces were returned
-    if (!ret || ret.status >= 400) {
+    if (!ret || ret.status === 503) {
+      toast({
+        title: t('toast.connection-error'),
+        status: 'error',
+        duration: 9000,
+        isClosable: true
+      })
+      return
+    }
+    if (ret.status >= 400) {
       if (ret.status === 403) {
         toast({
           title: t('toast.wrong-password'),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -78,8 +78,17 @@ export default function Home() {
   useEffect(() => {
     const runGetStages = async () => {
       const stages = await getStages()
-      setStageData(stages)
-      localStorage.setItem('bingoStageData', JSON.stringify(stages))
+      if (stages.status === 'error') {
+        toast({
+          title: t('toast.connection-error'),
+          status: 'error',
+          duration: 9000,
+          isClosable: true
+        })
+      } else {
+        setStageData(stages)
+        localStorage.setItem('bingoStageData', JSON.stringify(stages))
+      }
       if (document === undefined || document === null) return
       const getStagesEvent = new Event('getStagesEvent')
       document.querySelector('body')?.dispatchEvent(getStagesEvent)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,7 +87,7 @@ export default function Home() {
   useEffect(() => {
     const runGetStages = async () => {
       const stages = await getStages()
-      if (stages.status === 'error') {
+      if (stages.status === 503) {
         toast({
           title: t('toast.connection-error'),
           status: 'error',


### PR DESCRIPTION
Closes #77

- When unable to connect to get-stages, make a toast and use existing data
- Make a toast when there are no episodes to choose from
- Making a toast when the password api endpoint cannot be reached
- Making the status property of the return of getstages 503 too
